### PR TITLE
Fix universal builds on Darwin PPC: add ppc7400 definition

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -710,6 +710,7 @@ def darwin_get_object_archs(objpath: str) -> 'ImmutableListProtocol[str]':
     # Convert from lipo-style archs to meson-style CPUs
     stdo = stdo.replace('i386', 'x86')
     stdo = stdo.replace('arm64', 'aarch64')
+    stdo = stdo.replace('ppc7400', 'ppc')
     # Add generic name for armv7 and armv7s
     if 'armv7' in stdo:
         stdo += ' arm'


### PR DESCRIPTION
Solves the problem on Darwin PowerPC, when `meson` fails to identify `ppc7400` as `ppc`, which causes universal build failure.
Example: https://trac.macports.org/ticket/64787